### PR TITLE
faeture: Makefileにローカル用のコマンド追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,18 @@
+CLIENT_DIR := ./client
+STORYBOOK_DIR := ./story
+USER_API_DIR := ./api/user
+
+##################################################
+# Container Commands
+##################################################
 .PHONY: setup
 setup:
 	cp ./.env.sample ./.env
 	docker-compose build
+	$(MAKE) install
+
+.PHONY: install
+install:
 	docker-compose run client yarn
 	docker-compose run storybook yarn
 
@@ -9,14 +20,66 @@ setup:
 start:
 	docker-compose up
 
+##################################################
+# Local Commands - Client
+##################################################
 .PHONY: client-setup
 client-setup:
-	@docker-compose run client yarn
+	cp ${CLIENT_DIR}/.envrc.sample ${CLIENT_DIR}/.envrc
+	$(MAKE) client-install
+
+.PHONY: client-install
+client-install:
+	cd ${CLIENT_DIR}; yarn
+
+.PHONY: client-start
+client-start:
+	cd ${CLIENT_DIR}; yarn dev
 
 .PHONY: client-lint
 client-lint:
-	@docker-compose run client yarn lint
+	cd ${CLIENT_DIR}; yarn lint
 
-.PHONY: client-build
-client-build:
-	@docker-compose run client yarn build
+.PHONY: client-test
+client-test:
+	cd ${CLIENT_DIR}; yarn test
+
+##################################################
+# Local Commands - Storybook
+##################################################
+.PHONY: storybook-setup
+storybook-setup:
+	cp ${STORYBOOK_DIR}/.envrc.sample ${STORYBOOK_DIR}/.envrc
+	$(MAKE) storybook-install
+
+.PHONY: storybook-install
+storybook-install:
+	cd ${STORYBOOK_DIR}; yarn
+
+.PHONY: storybook-start
+storybook-start:
+	cd ${STORYBOOK_DIR}; yarn storybook
+
+.PHONY: storybook-lint
+	cd ${STORYBOOK_DIR}; yarn lint
+
+.PHONY: storybook-test
+	cd ${STORYBOOK_DIR}; yarn test
+
+##################################################
+# Local Commands - API (User Service)
+##################################################
+.PHONY: user-api-setup
+user-api-setup:
+	cp ${USER_API_DIR}/.envrc.sample ${USER_API_DIR}/.envrc
+
+.PHONY: user-api-start
+user-api-start:
+	cd ${USER_API_DIR}; make run
+
+.PHONY: user-api-lint
+	cd ${USER_API_DIR}; make fmt
+	cd ${USER_API_DIR}; make lint
+
+.PHONY: user-api-test
+	cd ${USER_API_DIR}; make test

--- a/Makefile
+++ b/Makefile
@@ -61,9 +61,11 @@ storybook-start:
 	cd ${STORYBOOK_DIR}; yarn storybook
 
 .PHONY: storybook-lint
+sotybook-lint:
 	cd ${STORYBOOK_DIR}; yarn lint
 
 .PHONY: storybook-test
+storybook-test:
 	cd ${STORYBOOK_DIR}; yarn test
 
 ##################################################
@@ -78,8 +80,10 @@ user-api-start:
 	cd ${USER_API_DIR}; make run
 
 .PHONY: user-api-lint
+user-api-lint:
 	cd ${USER_API_DIR}; make fmt
 	cd ${USER_API_DIR}; make lint
 
 .PHONY: user-api-test
+user-api-test:
 	cd ${USER_API_DIR}; make test

--- a/client/.envrc.sample
+++ b/client/.envrc.sample
@@ -1,0 +1,1 @@
+BASE_URL=http://localhost:3000

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -56,8 +56,9 @@ typings/
 # Yarn Integrity file
 .yarn-integrity
 
-# dotenv environment variables file
-.env
+# direnv environment variables file
+.envrc
+!.envrc.sample
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -25,10 +25,7 @@ const configuration: Configuration = {
     '@nuxtjs/stylelint-module',
     '@nuxtjs/vuetify'
   ],
-  modules: ['@nuxtjs/axios', '@nuxtjs/dotenv', '@nuxtjs/pwa'],
-  dotenv: {
-    path: '.'
-  },
+  modules: ['@nuxtjs/axios', '@nuxtjs/pwa'],
   typescript: {
     typeCheck: {
       eslint: true

--- a/client/package.json
+++ b/client/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@nuxt/typescript-runtime": "^0.3.2",
     "@nuxtjs/axios": "^5.3.6",
-    "@nuxtjs/dotenv": "^1.4.0",
     "@nuxtjs/pwa": "^3.0.0-0",
     "nuxt": "^2.0.0"
   },

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1202,14 +1202,6 @@
     consola "^2.11.1"
     defu "^0.0.3"
 
-"@nuxtjs/dotenv@^1.4.0":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@nuxtjs/dotenv/-/dotenv-1.4.1.tgz#dd5abb98e22cc7ae27139d3aa606151034293128"
-  integrity sha512-DpdObsvRwC8d89I9mzz6pBg6e/PEXHazDM57DOI1mmML2ZjHfQ/DvkjlSzUL7T+TnW3b/a4Ks5wQx08DqFBmeQ==
-  dependencies:
-    consola "^2.10.1"
-    dotenv "^8.1.0"
-
 "@nuxtjs/eslint-config-typescript@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@nuxtjs/eslint-config-typescript/-/eslint-config-typescript-1.0.0.tgz#5789acc63deb15eda9e5d523620cc06ea0dfd920"
@@ -3950,11 +3942,6 @@ dot-prop@^4.1.1:
   integrity sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==
   dependencies:
     is-obj "^1.0.0"
-
-dotenv@^8.1.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
-  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
 duplexer@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
やまゆーの言ってるのあってるかわからんが、ルートからMakeコマンドで全てのプロジェクト管理できるようにしました。
合わせて、環境変数の管理方法も統一させるため、clientディレクトリのdotenvをdirenvに変更しました。

コマンドは統一感持たせたかったので、以下の5つで実装

* setup
* install
* start
* lint
* test