### PR TITLE
feature: フォームグループコンポーネントの作成

### DIFF
--- a/client/app/components/atoms/GranFormGroup.vue
+++ b/client/app/components/atoms/GranFormGroup.vue
@@ -1,0 +1,7 @@
+<template>
+  <validation-observer v-slot="{ invalid }">
+    <form>
+      <slot :invalid="invalid" />
+    </form>
+  </validation-observer>
+</template>


### PR DESCRIPTION
## やったこと

<!-- なるべく箇条書きで -->
* VeeValidateが使えるようにしたForm Groupの作成

### レビュー時のポイント

<!-- レビュー時に見て欲しい部分を書く -->

## 残タスク

### 備考

<!-- マージ後に必要な操作などがあればここに -->

Moleculesとかにおきたかったけど、Moleculesでサインアップフォームとか実装するのでAtomsに配置しました。
パスワードの確認フォームとか実装するのに必要なるはずなので作成しました。

以下の感じで使えます。

```vue
<gran-form-group v-slot="props">
  <gran-text-field .. />

  <v-btn :disabled="props.invalid" @click="handleSubmit">送信</v-btn>
</gran-form-group>
```